### PR TITLE
Prevent duplicates in the history palette

### DIFF
--- a/ColorTools.lua
+++ b/ColorTools.lua
@@ -61,19 +61,26 @@ function ColorTools:gererateAllColorsTable()
 end
 
 
-ColorPickerFrame.Footer.OkayButton:HookScript('OnClick', function()  
+ColorPickerFrame.Footer.OkayButton:HookScript('OnClick', function()
 	local r, g, b = ColorPickerFrame:GetColorRGB();
 	local alpha = ColorPickerFrame:GetColorAlpha()
-	local color = {r, g ,b, alpha}
-	
-	if not _.isEmpty(ColorToolsLastUsed) then
-		if CreateColor(table.unpack(ColorToolsLastUsed[1].color)):IsEqualTo(CreateColor(table.unpack(color))) then 
-			return
+	local function short(v) return Round(v * 1e5) / 1e5 end
+	local color = {short(r), short(g), short(b), short(alpha)}
+	local dupe = false
+
+	for i, v in ipairs(ColorToolsLastUsed) do
+		if CreateColor(table.unpack(v.color)):IsEqualTo(CreateColor(table.unpack(color))) then
+			ColorToolsLastUsed[i].sort, dupe = time(), true
+			break
 		end
 	end
 
-	table.insert(ColorToolsLastUsed, 1, { sort = time(), color = color })
-	ColorToolsLastUsed = _.slice(ColorToolsLastUsed, 1, ColorTools.config.maxLastUsedColors)
+	if not dupe then
+		table.insert(ColorToolsLastUsed, 1, { sort = time(), color = color })
+		ColorToolsLastUsed = _.slice(ColorToolsLastUsed, 1, ColorTools.config.maxLastUsedColors)
+	else
+		table.sort(ColorToolsLastUsed, function(a, b) return a.sort > b.sort end)
+	end
 	ColorTools.colorPalettes["lastUsedColors"].colors = ColorToolsLastUsed
 end)
 


### PR DESCRIPTION
After selecting a color from the history I get a duplicate in the palette. This will quickly clutter the whole history with unnecessary dupes:

<img width="545" alt="image" src="https://github.com/user-attachments/assets/8b471af0-a91a-43a6-92e5-2acb9bcfa0f6">

---

This little change aims to prevent this. When an identical color is detected, it will be sorted first and no dupe is created.

---

Note: 

The truncating of the color values (lines 67/68) was necessary in order to make the `IsEqualTo` color comparison work reliably. Without it, it worked 80 or 90% of the time, but sometimes it returned a false negative and a dupe was created.

Not sure what the exact reason for this is, but it seems the API cannot handle comparisons of floats with 17 decimal places. (And I think 5 decimals are more than enough;)